### PR TITLE
Fix potential memory leak in LibraryInjector.

### DIFF
--- a/Software/libraryinjector/LibraryInjector.c
+++ b/Software/libraryinjector/LibraryInjector.c
@@ -443,16 +443,16 @@ LIBRARYINJECTORSHARED_EXPORT HRESULT PASCAL DllGetClassObject(REFCLSID objGuid, 
     reportLog(EVENTLOG_INFORMATION_TYPE, "factory guid %s", guida);
 #endif
 
-    ClassFactory * classFactory;
     if (IsEqualCLSID(objGuid, &CLSID_ILibraryInjector))
     {
-
-        classFactory = (ClassFactory *)GlobalAlloc(GMEM_FIXED, sizeof(ClassFactory));
+        ClassFactory * classFactory = (ClassFactory *)GlobalAlloc(GMEM_FIXED, sizeof(ClassFactory));
         _ClassFactory(classFactory);
+        classFactory->lpVtbl->AddRef(classFactory);
         // Fill in the caller's handle with a pointer to our IClassFactory object.
         // We'll let our IClassFactory's QueryInterface do that, because it also
         // checks the IClassFactory GUID and does other book-keeping
         hr = classFactory->lpVtbl->QueryInterface(classFactory, factoryGuid, factoryHandle);
+        classFactory->lpVtbl->Release(classFactory);
     }
     else
     {


### PR DESCRIPTION
Решил запостить для начала совсем маленький патчик.
Напишу по-русски, чтобы не пугать плохим английским, ОК?

Проблема в том, что если 
`objGuid == CLSID_ILibraryInjector` а factoryGuid будет каким-то нераспознанным библиотекой, то ClassFactory_QueryInterface просто вернет E_NOINTERFACE.
В результате объект ClassFactory не будет освобожден.

Перенес переменную classFactory под if, так как она снаружи не используется.
