### PR TITLE
Correct signature of ApiServer::incomingConnection

### DIFF
--- a/Software/src/ApiServer.cpp
+++ b/Software/src/ApiServer.cpp
@@ -227,7 +227,7 @@ void ApiServer::updateApiKey(const QString &key)
         m_isAuthEnabled = true;
 }
 
-void ApiServer::incomingConnection(int socketDescriptor)
+void ApiServer::incomingConnection(qintptr socketDescriptor)
 {
     QTcpSocket *client = new QTcpSocket(this);
     client->setSocketDescriptor(socketDescriptor);

--- a/Software/src/ApiServer.hpp
+++ b/Software/src/ApiServer.hpp
@@ -175,7 +175,7 @@ public slots:
     void updateApiKey(const QString &key);
 
 protected:
-    void incomingConnection(int socketDescriptor);
+    void incomingConnection(qintptr socketDescriptor);
 
 private slots:
     void clientDisconnected();


### PR DESCRIPTION
The signature of QTcpServer::incomingConnection has apparently changed between Qt4 and Qt5. 

http://qt-project.org/doc/qt-4.8/qtcpserver.html#incomingConnection
http://qt-project.org/doc/qt-5/qtcpserver.html#incomingConnection

Without this change the ApiServer isn't accepting any incoming connections (since the current signature doesn't override the correct method).

I assume from the build docs that Qt5 is the intended target for all platforms?  I wasn't able to get the tests under tests/ to run (unable to find ../src/grab/calculations.hpp) so I'm unsure if this breaks tests or not.
