### PR TITLE
Workaround for "no systray found" problem (issue 362)

### DIFF
--- a/Software/src/LightpackApplication.cpp
+++ b/Software/src/LightpackApplication.cpp
@@ -78,11 +78,15 @@ void LightpackApplication::initializeAll(const QString & appDirPath)
 
     if (!m_noGui)
     {
-        checkSystemTrayAvailability();
+        bool trayAvailable = checkSystemTrayAvailability();
 
         m_settingsWindow = new SettingsWindow();
-        m_settingsWindow->setVisible(false); /* Load to tray */
-        m_settingsWindow->createTrayIcon();
+        if (trayAvailable) {
+            m_settingsWindow->setVisible(false); /* Load to tray */
+            m_settingsWindow->createTrayIcon();
+        }
+        else
+            m_settingsWindow->setVisible(true);
         m_settingsWindow->connectSignalsSlots();
         connect(this, SIGNAL(postInitialization()), m_settingsWindow, SLOT(onPostInit()));
 //        m_settingsWindow->profileSwitch(Settings::getCurrentProfileName());
@@ -418,7 +422,7 @@ void LightpackApplication::printVersionsSoftwareQtOS() const
     }
 }
 
-void LightpackApplication::checkSystemTrayAvailability() const
+bool LightpackApplication::checkSystemTrayAvailability() const
 {
 #   ifdef Q_OS_LINUX
     // When you add lightpack in the Startup in Ubuntu (10.04), tray starts later than the application runs.
@@ -435,8 +439,10 @@ void LightpackApplication::checkSystemTrayAvailability() const
     if (QSystemTrayIcon::isSystemTrayAvailable() == false)
     {
         QMessageBox::critical(0, "Prismatik", "I couldn't detect any system tray on this system.");
-        qFatal("%s %s", Q_FUNC_INFO, "I couldn't detect any system tray on this system.");
+        DEBUG_LOW_LEVEL << Q_FUNC_INFO << "Systray couldn't be detected, running in trayless mode";
+        return false;
     }
+    return true;
 }
 
 void LightpackApplication::startApiServer()

--- a/Software/src/LightpackApplication.hpp
+++ b/Software/src/LightpackApplication.hpp
@@ -84,7 +84,7 @@ private:
     void processCommandLineArguments();
     void printHelpMessage() const;
     void printVersionsSoftwareQtOS() const;
-    void checkSystemTrayAvailability() const;
+    bool checkSystemTrayAvailability() const;
     void startApiServer();
     void startLedDeviceManager();
     void initGrabManager();

--- a/Software/src/SettingsWindow.cpp
+++ b/Software/src/SettingsWindow.cpp
@@ -276,7 +276,8 @@ void SettingsWindow::changeEvent(QEvent *e)
 
         currentPage = ui->listWidget->currentRow();
         ui->retranslateUi(this);
-        m_trayIcon->retranslateUi();
+        if (m_trayIcon)
+            m_trayIcon->retranslateUi();
 
         ui->comboBox_LightpackModes->setCurrentIndex(Settings::getLightpackMode() == Lightpack::MoodLampMode ? MoodLampModeIndex : GrabModeIndex);
 
@@ -302,10 +303,14 @@ void SettingsWindow::closeEvent(QCloseEvent *event)
 {
     DEBUG_LOW_LEVEL << Q_FUNC_INFO;
 
-    if(m_trayIcon->isVisible()){
+    if (m_trayIcon && m_trayIcon->isVisible()) {
         // Just hide settings
         hideSettings();
         event->ignore();
+    }
+    else {
+        // terminate application if we're running in "trayless" mode
+        QApplication::quit();
     }
 }
 
@@ -690,15 +695,18 @@ void SettingsWindow::updateTrayAndActionStates()
         if (m_deviceLockStatus == DeviceLocked::Api)
         {
             m_labelStatusIcon->setPixmap(*m_pixmapCache["lock16"]);
-            m_trayIcon->setStatus(SysTrayIcon::StatusLockedByApi);
+            if (m_trayIcon)
+                m_trayIcon->setStatus(SysTrayIcon::StatusLockedByApi);
         } else
             if (m_deviceLockStatus == DeviceLocked::Plugin)
             {
                 m_labelStatusIcon->setPixmap(*m_pixmapCache["lock16"]);
-                m_trayIcon->setStatus(SysTrayIcon::StatusLockedByPlugin, &m_deviceLockModule);
+                if (m_trayIcon)
+                    m_trayIcon->setStatus(SysTrayIcon::StatusLockedByPlugin, &m_deviceLockModule);
             } else {
                 m_labelStatusIcon->setPixmap(*m_pixmapCache["on16"]);
-                m_trayIcon->setStatus(SysTrayIcon::StatusOn);
+                if (m_trayIcon)
+                    m_trayIcon->setStatus(SysTrayIcon::StatusOn);
             }
         break;
 
@@ -706,20 +714,23 @@ void SettingsWindow::updateTrayAndActionStates()
         m_labelStatusIcon->setPixmap(*m_pixmapCache["off16"]);
         ui->pushButton_EnableDisableDevice->setIcon(QIcon(*m_pixmapCache["on16"]));
         ui->pushButton_EnableDisableDevice->setText("  " + tr("Turn lights ON"));
-        m_trayIcon->setStatus(SysTrayIcon::StatusOff);
+        if (m_trayIcon)
+            m_trayIcon->setStatus(SysTrayIcon::StatusOff);
         break;
 
     case Backlight::StatusDeviceError:
         m_labelStatusIcon->setPixmap(*m_pixmapCache["error16"]);
         ui->pushButton_EnableDisableDevice->setIcon(QIcon(*m_pixmapCache["off16"]));
         ui->pushButton_EnableDisableDevice->setText("  " + tr("Turn lights OFF"));
-        m_trayIcon->setStatus(SysTrayIcon::StatusError);
+        if (m_trayIcon)
+            m_trayIcon->setStatus(SysTrayIcon::StatusError);
         break;
     default:
         qWarning() << Q_FUNC_INFO << "m_backlightStatus = " << m_backlightStatus;
         break;
     }
-    m_labelStatusIcon->setToolTip(m_trayIcon->toolTip());
+    if (m_trayIcon)
+        m_labelStatusIcon->setToolTip(m_trayIcon->toolTip());
 }
 
 void SettingsWindow::initGrabbersRadioButtonsVisibility()
@@ -1248,7 +1259,8 @@ void SettingsWindow::profileSwitch(const QString & configName)
 
     ui->comboBox_Profiles->setCurrentIndex(index);
 
-    m_trayIcon->updateProfiles();
+    if (m_trayIcon)
+        m_trayIcon->updateProfiles();
 
     Settings::loadOrCreateProfile(configName);
 


### PR DESCRIPTION
Well, it seems there is some problem in Qt framework that prevents
system tray to be detected. Currently, (Qt 5.3.0-beta) it is not
resolved. So, introduce "trayless" mode for such a cases when Qt unable
to access the systray feature. In this mode SettingsWindow is visible
after start and when user closes the window, just terminate the
application.
