### PR TITLE
[firmware] Add macro to switch off enclosure LED

### DIFF
--- a/Firmware/LUFAConfig.h
+++ b/Firmware/LUFAConfig.h
@@ -64,6 +64,7 @@
 //		#define USB_STREAM_TIMEOUT_MS            {Insert Value Here}
 //		#define NO_LIMITED_CONTROLLER_CONNECT
 //		#define NO_SOF_EVENTS
+//		#define ENCLOSURE_LED_OFF
 		/* USB Device Mode Driver Related Tokens: */
 //		#define USE_RAM_DESCRIPTORS
 		#define USE_FLASH_DESCRIPTORS

--- a/Firmware/Lightpack.c
+++ b/Firmware/Lightpack.c
@@ -148,6 +148,7 @@ int main(void)
     enableWatchdog();
     SetupHardware();
     _WaveSwitchOnUsbLed(100, 100);
+
     // Led driver ports initialization
     LedDriver_Init();
 
@@ -158,6 +159,10 @@ int main(void)
     USB_Init();
 
     sei();
+
+#ifdef ENCLOSURE_LED_OFF
+    CLR(USBLED);
+#endif
 
     for (;;)
     {

--- a/Firmware/Lightpack.h
+++ b/Firmware/Lightpack.h
@@ -78,7 +78,7 @@ static inline void _BlinkUsbLed(const uint8_t times, const uint8_t ms)
 }
 
 static inline void _WaveSwitchOnUsbLed(const uint8_t num, const uint8_t target)
-{                                                                               
+{
     for (uint8_t pwm = 0; pwm < num; pwm++)
     {
         CLR(USBLED);


### PR DESCRIPTION
If macro ENCLOSURE_LED_OFF is enabled in the LUFAConfig.h file,
the enclosure LED will be switched off after bootup. The macro is
disabled by default.